### PR TITLE
Update Arch-Wiki link to systemd-cryptenroll

### DIFF
--- a/fde-tpm-sb.html
+++ b/fde-tpm-sb.html
@@ -760,7 +760,7 @@ back the key only if a kernel with the right signature is booted. This ensures
 that we have a chain of trust from the EFI firmware (which we will check too).</p>
 <p>We are going to do this on <em>Debian unstable</em>, but it should work with other
 <em>Debian</em>-based distros like <em>Ubuntu</em>. If you are on <em>ArchLinux</em>, it looks like
-there is almost nothing to do as everything is handled by <a class="reference external" href="https://wiki.archlinux.org/title/Trusted_Platform_Module#systemd-cryptenroll">systemd-cryptenroll</a>.
+there is almost nothing to do as everything is handled by <a class="reference external" href="https://wiki.archlinux.org/title/Systemd-cryptenroll#Trusted_Platform_Module">systemd-cryptenroll</a>.
 While <span class="docutils literal"><span class="pre">systemd-cryptenroll</span></span> probably works on <em>Debian</em>, it does not work with
 an encrypted root partition.</p>
 <section id="set-up-secure-boot-with-your-own-keys">


### PR DESCRIPTION
The former link pointed to this new location.